### PR TITLE
fix: ビルド成果物が`public`ディレクトリへ出力されるように変更

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yaml
+++ b/.github/workflows/deploy-to-github-pages.yaml
@@ -31,8 +31,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install trunk
-        run: cargo install --locked trunk
+      - name: Install trunk binary
+        run: cargo binstall trunk
 
       - name: Add target for wasm
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/deploy-to-github-pages.yaml
+++ b/.github/workflows/deploy-to-github-pages.yaml
@@ -41,7 +41,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build App
-        run: trunk build --release --minify --public-url ${{ env.REPOSITORY_NAME }}
+        run: |
+          trunk build --release --minify --dist public --public-url ${{ env.REPOSITORY_NAME }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -49,7 +50,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./dist
+          path: ./public
 
   deploy:
     needs: build


### PR DESCRIPTION
参考
- [Rust + Yew で静的ページをGitHub Pagesにデプロイ](https://qiita.com/suzuki_sh/items/c53a6056bb4377a50861)
