### PR TITLE
fix: `Binstall`のインストールstepを追加

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yaml
+++ b/.github/workflows/deploy-to-github-pages.yaml
@@ -31,6 +31,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install Binstall
+        uses: cargo-bins/cargo-binstall@v1
+
       - name: Install trunk binary
         run: cargo binstall trunk
 


### PR DESCRIPTION
GitHub Actions用のアクションもあるので、それを利用してインストール
- https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file#in-github-actions