### PR TITLE
fix: rootからの相対パスとして明示

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yaml
+++ b/.github/workflows/deploy-to-github-pages.yaml
@@ -22,6 +22,9 @@ jobs:
     permissions:
       contents: read
 
+    env:
+      REPOSITORY_NAME: ${{ github.event.repository.name }}
+
     runs-on: ubuntu-latest
 
     steps:
@@ -42,7 +45,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build App
-        run: trunk build --release --minify
+        run: trunk build --release --minify --public-url ${{ env.REPOSITORY_NAME }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/deploy-to-github-pages.yaml
+++ b/.github/workflows/deploy-to-github-pages.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build App
-        run: trunk build --release --minify --public-url ${{ env.REPOSITORY_NAME }}
+        run: trunk build --release --minify --public-url "/${{ env.REPOSITORY_NAME }}"
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="utf-8" />
     <title>QR Code Generator</title>
+    <base data-trunk-public-url />
 </head>
 
 <body></body>


### PR DESCRIPTION
- `<base>`指定も`public-url`指定もない場合、ビルドしたJS/WASMの参照パスがルート直下となっている
- これをリポジトリ名直下へ変更できれば問題なさそう