### PR TITLE
#3: QRコード画像を生成できるように対応

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
+workspace = { members = [ "qr-code-wrapper" ] }
+
 [package]
 name = "qr-code-generator-webapp-rust"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+qr-code-wrapper = { path = "./qr-code-wrapper" }
+web-sys = "0.3.76"
 yew = { git = "https://github.com/yewstack/yew/", features = ["csr"] }

--- a/qr-code-wrapper/Cargo.toml
+++ b/qr-code-wrapper/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "qr-code-wrapper"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+base64 = "0.22.1"
+qrcode-generator = "5.0.0"

--- a/qr-code-wrapper/src/lib.rs
+++ b/qr-code-wrapper/src/lib.rs
@@ -1,0 +1,18 @@
+//! This is a library crate for wrapping [`qrcode-generator`](https://docs.rs/qrcode-generator/latest/qrcode_generator/) crate.
+
+extern crate qrcode_generator;
+
+use base64::{engine::general_purpose::STANDARD, Engine};
+pub use qrcode_generator::*;
+
+/// Encode text to base64 string of a PNG image in memory.
+#[inline]
+pub fn to_png_to_base64_str_from_str<S: AsRef<str>>(
+    text: S,
+    ecc: QrCodeEcc,
+    size: usize,
+) -> Result<String, QRCodeError> {
+    let png = to_png_to_vec_from_str(text, ecc, size)?;
+    let base64_encoded_str = STANDARD.encode(png);
+    Ok(base64_encoded_str)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,33 +1,63 @@
+use qr_code_wrapper::*;
+use web_sys::HtmlInputElement;
 use yew::prelude::*;
-
-#[function_component(App)]
-fn app() -> Html {
-    html! {
-        <>
-            <h1>{ "Hello QR Code Generator" }</h1>
-            <Counter />
-        </>
-    }
-}
-
-#[function_component(Counter)]
-fn counter() -> Html {
-    let counter = use_state(|| 0);
-    let onclick = {
-        let counter = counter.clone();
-        move |_| {
-            let value = *counter + 1;
-            counter.set(value);
-        }
-    };
-    html! {
-        <div>
-            <button {onclick}>{"+1"}</button>
-            <p>{*counter}</p>
-        </div>
-    }
-}
 
 fn main() {
     yew::Renderer::<App>::new().render();
+}
+
+#[function_component(App)]
+fn app() -> Html {
+    let input_ref = use_node_ref();
+
+    let url_updator = use_state(|| "".to_string());
+
+    let onsubmit = {
+        let input_ref = input_ref.clone();
+        let url_updator = url_updator.clone();
+        move |e: SubmitEvent| {
+            e.prevent_default();
+            url_updator.set(input_ref.cast::<HtmlInputElement>().unwrap().value());
+        }
+    };
+
+    html! {
+        <main>
+            <form {onsubmit}>
+                <label>
+                    {"Input URL:"}
+                    // TODO: バリデーション
+                    // TODO: 入力文字数の制限
+                    <input ref={input_ref.clone()} type="url" placeholder="https://example.com" required=true />
+                </label>
+                <button type="submit">{"Generate QR Code"}</button>
+            </form>
+            <QrCodeImage url={(*url_updator).clone()} />
+        </main>
+    }
+}
+
+#[derive(Properties, PartialEq, Clone)]
+struct QrCodeProps {
+    url: AttrValue,
+}
+
+#[function_component(QrCodeImage)]
+fn qr_code_image(props: &QrCodeProps) -> Html {
+    let QrCodeProps { url } = props.clone();
+    let url = url.clone();
+    if url.is_empty() {
+        // TODO: ここにQRコードが出力されることを示す、プレースホルダ画像を表示したい
+        return Html::default();
+    }
+
+    let base64_encoded_image_data =
+        qr_code_wrapper::to_png_to_base64_str_from_str(&url, QrCodeEcc::Low, 256).unwrap();
+    let img = format!("data:image/png;base64,{}", base64_encoded_image_data);
+    // TODO: QRコードが表示されるまで loading 表示をしたい
+    html! {
+        <>
+            <img src={img} alt={&url} />
+        </>
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,13 @@ fn app() -> Html {
                 <label>
                     {"Input URL:"}
                     // TODO: バリデーション
-                    // TODO: 入力文字数の制限
-                    <input ref={input_ref.clone()} type="url" placeholder="https://example.com" required=true />
+                    <input
+                        ref={input_ref.clone()}
+                        type="url"
+                        placeholder="https://example.com"
+                        required=true
+                        maxlength=2048
+                    />
                 </label>
                 <button type="submit">{"Generate QR Code"}</button>
             </form>


### PR DESCRIPTION
- QRコード画像生成には `qrcode-generator` crate を使用
- 画像表示は `base64` crateにより、画像バイナリデータを base64 エンコードして指定